### PR TITLE
Hotfix/networking

### DIFF
--- a/configs/overlay_rootfs/scripts/watchdog.sh
+++ b/configs/overlay_rootfs/scripts/watchdog.sh
@@ -7,28 +7,30 @@ router=`ip route | awk '/default/ { print $3 }'`
 count=0
 wifi_error=0
 while sleep 20 ; do
+  let count++
+
   # wifi
   if ping -c 1 $router > /dev/null ; then
     wifi_error=0
+
+    # process check 1min interval
+      if [ `expr $count % 3` -eq 0 ]; then
+        /scripts/lighttpd.sh watchdog >> /media/mmc/atomhack.log
+        /scripts/rtspserver.sh watchdog >> /media/mmc/atomhack.log
+
+        HEALTHCHECK=$(awk -F "=" '/HEALTHCHECK *=/ {print $2}' $HACK_INI)
+        HEALTHCHECK_PING_URL=$(awk -F "=" '/HEALTHCHECK_PING_URL *=/ {print $2}' $HACK_INI)
+        [ "$HEALTHCHECK" == "on" ] && [ "$HEALTHCHECK_PING_URL" != "" ] && echo $(date) >> /media/mmc/healthcheck.log && curl -fsS -m 10 --retry 5 -o /dev/null $HEALTHCHECK_PING_URL
+      fi
   else
     let wifi_error++
   fi
+
   if [ $wifi_error -ge 3 ]; then
     echo "WiFi restart" >> /media/mmc/atomhack.log
     ifconfig wlan0 down
     ifconfig wlan0 up
     wifi_error=0
-  fi
-
-  let count++
-
-  # process check 1min interval
-  if [ `expr $count % 3` -eq 0 ]; then
-    /scripts/lighttpd.sh watchdog >> /media/mmc/atomhack.log
-    /scripts/rtspserver.sh watchdog >> /media/mmc/atomhack.log
-    HEALTHCHECK=$(awk -F "=" '/HEALTHCHECK *=/ {print $2}' $HACK_INI)
-    HEALTHCHECK_PING_URL=$(awk -F "=" '/HEALTHCHECK_PING_URL *=/ {print $2}' $HACK_INI)
-    [ "$HEALTHCHECK" == "on" ] && [ "$HEALTHCHECK_PING_URL" != "" ] && curl -fsS -m 10 --retry 5 -o /tmp/log/healthcheck.log $HEALTHCHECK_PING_URL
   fi
 
   # free memory
@@ -38,6 +40,3 @@ while sleep 20 ; do
     free >> /media/mmc/atomhack.log
   fi
 done
-
-
-

--- a/configs/overlay_rootfs/scripts/watchdog.sh
+++ b/configs/overlay_rootfs/scripts/watchdog.sh
@@ -7,7 +7,7 @@ router=`ip route | awk '/default/ { print $3 }'`
 count=0
 wifi_error=0
 while sleep 20 ; do
-  count++
+  let count++
 
   # wifi
   if ping -c 1 $router > /dev/null ; then
@@ -23,7 +23,7 @@ while sleep 20 ; do
       [ "$HEALTHCHECK" == "on" ] && [ "$HEALTHCHECK_PING_URL" != "" ] && echo $(TZ=JST-9 date +"%Y/%m/%d %H:%M:%S") >> /media/mmc/healthcheck.log && curl -fsS -m 10 --retry 5 $HEALTHCHECK_PING_URL >> /media/mmc/healthcheck.log
     fi
   else
-    wifi_error++
+    let wifi_error++
   fi
 
   if [ $wifi_error -ge 3 ]; then

--- a/configs/overlay_rootfs/scripts/watchdog.sh
+++ b/configs/overlay_rootfs/scripts/watchdog.sh
@@ -3,13 +3,13 @@
 HACK_INI=/tmp/hack.ini
 echo `TZ=JST-9 date +"%Y/%m/%d %H:%M:%S"` ": Reboot & Start watchdog" >> /media/mmc/atomhack.log
 
-router=`ip route | awk '/default/ { print $3 }'`
 count=0
 wifi_error=0
 while sleep 20 ; do
   let count++
 
   # wifi
+  router=`ip route | awk '/default/ { print $3 }'`
   if ping -c 1 $router > /dev/null ; then
     wifi_error=0
 

--- a/configs/overlay_rootfs/scripts/watchdog.sh
+++ b/configs/overlay_rootfs/scripts/watchdog.sh
@@ -20,7 +20,7 @@ while sleep 20 ; do
 
       HEALTHCHECK=$(awk -F "=" '/HEALTHCHECK *=/ {print $2}' $HACK_INI)
       HEALTHCHECK_PING_URL=$(awk -F "=" '/HEALTHCHECK_PING_URL *=/ {print $2}' $HACK_INI)
-      [ "$HEALTHCHECK" == "on" ] && [ "$HEALTHCHECK_PING_URL" != "" ] && echo `TZ=JST-9 date +"%Y/%m/%d %H:%M:%S"` >> /media/mmc/healthcheck.log && curl -fsS -m 10 --retry 5 -o /dev/null $HEALTHCHECK_PING_URL
+      [ "$HEALTHCHECK" == "on" ] && [ "$HEALTHCHECK_PING_URL" != "" ] && echo `TZ=JST-9 date +"%Y/%m/%d %H:%M:%S"` >> /media/mmc/healthcheck.log && curl -fsS -m 10 --retry 5 $HEALTHCHECK_PING_URL >> /media/mmc/healthcheck.log
     fi
   else
     let wifi_error++

--- a/configs/overlay_rootfs/scripts/watchdog.sh
+++ b/configs/overlay_rootfs/scripts/watchdog.sh
@@ -1,15 +1,15 @@
 #!/bin/sh
 
 HACK_INI=/tmp/hack.ini
-echo `TZ=JST-9 date +"%Y/%m/%d %H:%M:%S"` ": Reboot & Start watchdog" >> /media/mmc/atomhack.log
+echo $(TZ=JST-9 date +"%Y/%m/%d %H:%M:%S") ": Reboot & Start watchdog" >> /media/mmc/atomhack.log
 
+router=`ip route | awk '/default/ { print $3 }'`
 count=0
 wifi_error=0
 while sleep 20 ; do
-  let count++
+  count++
 
   # wifi
-  router=`ip route | awk '/default/ { print $3 }'`
   if ping -c 1 $router > /dev/null ; then
     wifi_error=0
 
@@ -20,10 +20,10 @@ while sleep 20 ; do
 
       HEALTHCHECK=$(awk -F "=" '/HEALTHCHECK *=/ {print $2}' $HACK_INI)
       HEALTHCHECK_PING_URL=$(awk -F "=" '/HEALTHCHECK_PING_URL *=/ {print $2}' $HACK_INI)
-      [ "$HEALTHCHECK" == "on" ] && [ "$HEALTHCHECK_PING_URL" != "" ] && echo `TZ=JST-9 date +"%Y/%m/%d %H:%M:%S"` >> /media/mmc/healthcheck.log && curl -fsS -m 10 --retry 5 $HEALTHCHECK_PING_URL >> /media/mmc/healthcheck.log
+      [ "$HEALTHCHECK" == "on" ] && [ "$HEALTHCHECK_PING_URL" != "" ] && echo $(TZ=JST-9 date +"%Y/%m/%d %H:%M:%S") >> /media/mmc/healthcheck.log && curl -fsS -m 10 --retry 5 $HEALTHCHECK_PING_URL >> /media/mmc/healthcheck.log
     fi
   else
-    let wifi_error++
+    wifi_error++
   fi
 
   if [ $wifi_error -ge 3 ]; then

--- a/configs/overlay_rootfs/scripts/watchdog.sh
+++ b/configs/overlay_rootfs/scripts/watchdog.sh
@@ -14,14 +14,14 @@ while sleep 20 ; do
     wifi_error=0
 
     # process check 1min interval
-      if [ `expr $count % 3` -eq 0 ]; then
-        /scripts/lighttpd.sh watchdog >> /media/mmc/atomhack.log
-        /scripts/rtspserver.sh watchdog >> /media/mmc/atomhack.log
+    if [ `expr $count % 3` -eq 0 ]; then
+      /scripts/lighttpd.sh watchdog >> /media/mmc/atomhack.log
+      /scripts/rtspserver.sh watchdog >> /media/mmc/atomhack.log
 
-        HEALTHCHECK=$(awk -F "=" '/HEALTHCHECK *=/ {print $2}' $HACK_INI)
-        HEALTHCHECK_PING_URL=$(awk -F "=" '/HEALTHCHECK_PING_URL *=/ {print $2}' $HACK_INI)
-        [ "$HEALTHCHECK" == "on" ] && [ "$HEALTHCHECK_PING_URL" != "" ] && echo $(date) >> /media/mmc/healthcheck.log && curl -fsS -m 10 --retry 5 -o /dev/null $HEALTHCHECK_PING_URL
-      fi
+      HEALTHCHECK=$(awk -F "=" '/HEALTHCHECK *=/ {print $2}' $HACK_INI)
+      HEALTHCHECK_PING_URL=$(awk -F "=" '/HEALTHCHECK_PING_URL *=/ {print $2}' $HACK_INI)
+      [ "$HEALTHCHECK" == "on" ] && [ "$HEALTHCHECK_PING_URL" != "" ] && echo `TZ=JST-9 date +"%Y/%m/%d %H:%M:%S"` >> /media/mmc/healthcheck.log && curl -fsS -m 10 --retry 5 -o /dev/null $HEALTHCHECK_PING_URL
+    fi
   else
     let wifi_error++
   fi


### PR DESCRIPTION
`ip route default` should exist after wifi connection is established.
When there no wifi connection is made, there should be no value.
So the value may be grabbed when there is still no connection, and ping-ing to an incorrect address since then.

Log before and after healthcheck, to determine if there is Internet (rather than LAN) connection issue.