### PR TITLE
[compose.yml,Makefile] docker レガシーコマンドから移行

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ docker-build:
 		tee docker-build_`date +"%Y%m%d_%H%M%S"`.log
 
 login:
-	$(call check_container_running) && $(DOCKER_COMPOSE) up -d
+	$(call check_container_running) || $(DOCKER_COMPOSE) up -d
 	$(DOCKER_COMPOSE) exec builder bash
 
 lima:

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,59 @@
 # Makefile
 .SILENT:
 
-DOCKER_IMAGE=$(shell sed -ne 's/^.*image:[ \t]*//p' docker-compose.yml)
-DOCKER_ARCH=-$(subst x86_64,amd64,$(subst aarch64,arm64,$(shell uname -m)))
+DOCKER_IMAGE=$(shell sed -ne 's>^.*image:[ \t]*>>p' docker-compose.yml)
+DOCKER_ARCH=-$(shell uname -m | sed 's>x86_64>amd64>g; s>aarch64>arm64>g')
+
+define check_container_running
+	$(DOCKER_COMPOSE) ls | grep atomcam_tools > /dev/null
+endef
+
+DOCKER_COMPOSE=$(shell \
+	if command -v docker-compose >/dev/null 2>&1; then \
+		echo "docker-compose"; \
+	elif docker compose version >/dev/null 2>&1; then \
+		echo "docker compose"; \
+	else \
+		echo "docker compose"; \
+	fi)
+
 
 build:
-	-docker pull ${DOCKER_IMAGE} | awk '{ print } /Downloaded newer image/ { system("docker-compose down"); }'
-	docker-compose ls | grep atomcam_tools > /dev/null || docker-compose up -d
-	docker-compose exec builder /src/buildscripts/build_all | tee rebuild_`date +"%Y%m%d_%H%M%S"`.log
+	-docker pull ${DOCKER_IMAGE} | \
+		awk '{ print } /Downloaded newer image/ { system("$(DOCKER_COMPOSE) down"); }'
+	
+	$(call check_container_running) || $(DOCKER_COMPOSE) up -d
+	
+	$(DOCKER_COMPOSE) exec builder /src/buildscripts/build_all | \
+		tee rebuild_`date +"%Y%m%d_%H%M%S"`.log
 
 build-local:
-	docker-compose ls | grep atomcam_tools > /dev/null || docker-compose up -d
-	docker-compose exec builder /src/buildscripts/build_all | tee rebuild_`date +"%Y%m%d_%H%M%S"`.log
+	$(call check_container_running) || $(DOCKER_COMPOSE) up -d
+	
+	$(DOCKER_COMPOSE) exec builder /src/buildscripts/build_all | \
+		tee rebuild_`date +"%Y%m%d_%H%M%S"`.log
 
 docker-build:
-	# build container
-	docker build -t ${DOCKER_IMAGE}${DOCKER_ARCH} . | tee docker-build_`date +"%Y%m%d_%H%M%S"`.log
+	docker build -t ${DOCKER_IMAGE}${DOCKER_ARCH} . | \
+		tee docker-build_`date +"%Y%m%d_%H%M%S"`.log
 
 login:
-	docker-compose ls | grep atomcam_tools > /dev/null || docker-compose up -d
-	docker-compose exec builder bash
+	$(call check_container_running) && $(DOCKER_COMPOSE) up -d
+	$(DOCKER_COMPOSE) exec builder bash
 
 lima:
 	[ "`uname -s`" = "Darwin" ] || exit 0
-	[ -d ~/.lima/lima-docker ] || ( limactl start --tty=false lima-docker.yml && exit 0 )
-	[ "`limactl list | awk '/lima-docker/ { print $2 }'`" = "Running" ] || limactl start lima-docker
+	
+	[ -d ~/.lima/lima-docker ] || \
+		( limactl start --tty=false lima-docker.yml && exit 0 )
+	
+	[ "`limactl list | awk '/lima-docker/ { print $2 }'`" = "Running" ] || \
+		limactl start lima-docker
+
+clean:
+	$(call check_container_running) && \
+		$(DOCKER_COMPOSE) exec builder bash -c "cd /atomtools/build/buildroot-2016.02 && make clean"
+
+distclean:
+	$(DOCKER_COMPOSE) down --volumes --remove-orphans
+	docker image rm ${DOCKER_IMAGE}${DOCKER_ARCH} 2>/dev/null || :

--- a/buildscripts/build_all
+++ b/buildscripts/build_all
@@ -10,7 +10,7 @@ cp -dpf staging/usr/lib/libstdc++.so* target/usr/lib/
 find ./build -name ".stamp_target_installed*" -print | xargs rm -f
 cd /atomtools/build/buildroot-2016.02
 cp /src/configs/atomcam_defconfig .config
-make oldconfig
+make olddefconfig
 for i in `ls /src/custompackages/package`
 do
   if ! diff -urb /src/custompackages/package/$i package/$i > /dev/null 2>&1 ; then


### PR DESCRIPTION
### [compose.yml]
  - docker-compose.ymlからcompose.ymlに変更しました
  - これはCompose仕様が Docker社から独立し、OCIの一部となったことを反映しています
  - 別のオーケストレーションツールが認識しないことがありますため将来的に変更としました

### [Makefile]
  - 互換性を保つために'docker compose'と'docker-compose'コマンドの両方を使えるようにしました
  - docker自身がcompose機能を担うようになったので最新版だとdocker composeのみとなりdocker-composeがdeprecatedとなりました
